### PR TITLE
Migrate to JDA 5 and replace jdautilities (copilot)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,12 +34,12 @@ repositories {
 	mavenLocal()
 	mavenCentral()
 	jcenter()
-	maven { // JDA
+	maven { // JDA (fallback)
 		name 'm2-dv8tion'
 		url 'https://m2.dv8tion.net/releases'
 	}
 
-	maven { // JDA-Chewtils
+	maven { // JDA-Chewtils (fallback)
 		url "https://m2.chew.pro/releases"
 	}
 }
@@ -47,15 +47,20 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	implementation 'net.dv8tion:JDA:4.4.0_352'
-	implementation 'pw.chew:jda-chewtils:1.24.1'
+	// Upgrade to JDA 5
+	implementation 'net.dv8tion:JDA:5.0.0'
+
+	// Keep Lavaplayer
 	implementation 'com.sedmelluq:lavaplayer:1.3.78'
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
-	testImplementation('org.springframework.boot:spring-boot-starter-test') {
+	// Remove pw.chew:jda-chewtils and rely on in-repo compatibility shims for jdautilities
+
+testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
-	testImplementation 'org.springframework.amqp:spring-rabbit-test'
+
+testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }
 
 docker {
@@ -69,5 +74,5 @@ docker {
 test {
 	useJUnitPlatform()
 	// it should pass all JVM options to the app started via test gradle task
-	systemProperties = System.properties // https://stackoverflow.com/questions/25079244/how-to-pass-jvm-options-from-bootrun/25079415
+	systemProperties = System.properties // https://stackoverflow.com/questions/25079444/how-to-pass-jvm-options-from-bootrun/25079415
 }

--- a/src/main/java/io/github/brendonmiranda/bot/clancy/command/CommandRouter.java
+++ b/src/main/java/io/github/brendonmiranda/bot/clancy/command/CommandRouter.java
@@ -1,0 +1,53 @@
+package io.github.brendonmiranda.bot.clancy.command;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Small router to register and dispatch slash commands to MusicCmd implementations.
+ */
+@Component
+public class CommandRouter extends ListenerAdapter {
+
+    private final JDA jda;
+    private final List<MusicCmd> commands;
+
+    public CommandRouter(JDA jda, List<MusicCmd> commands) {
+        this.jda = jda;
+        this.commands = commands;
+    }
+
+    @PostConstruct
+    public void registerCommands() {
+        // Build command data for all discovered commands
+        var commandData = commands.stream()
+            .map(cmd -> Commands.slash(cmd.name, cmd.help))
+            .collect(Collectors.toList());
+
+        // Register as global commands (or adjust for a test guild for immediate testing)
+        jda.updateCommands().addCommands(commandData).queue();
+
+        // register this listener
+        jda.addEventListener(this);
+    }
+
+    @Override
+    public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
+        String name = event.getName();
+        for (MusicCmd cmd : commands) {
+            if (cmd.name != null && cmd.name.equalsIgnoreCase(name)) {
+                cmd.execute(event);
+                return;
+            }
+        }
+        // If not found, reply gracefully
+        event.reply("Unknown command.").setEphemeral(true).queue();
+    }
+}

--- a/src/main/java/io/github/brendonmiranda/bot/clancy/command/MusicCmd.java
+++ b/src/main/java/io/github/brendonmiranda/bot/clancy/command/MusicCmd.java
@@ -1,70 +1,76 @@
 package io.github.brendonmiranda.bot.clancy.command;
 
-import com.jagrosh.jdautilities.command.SlashCommand;
-import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import io.github.brendonmiranda.bot.clancy.listener.AudioSendHandlerImpl;
 import io.github.brendonmiranda.bot.clancy.util.MessageUtil;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.managers.AudioManager;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+
+import java.util.List;
 
 /**
- * @author brendonmiranda
+ * Minimal replacement for jdautilities' SlashCommand base used by this project.
  */
-public abstract class MusicCmd extends SlashCommand {
+public abstract class MusicCmd {
 
-	public MusicCmd() {
-		this.guildOnly = true;
-		this.category = new Category("Music");
-	}
+    // command metadata (set in constructors of concrete commands)
+    public String name;
+    public String help;
+    public boolean guildOnly = true;
+    public List<OptionData> options;
 
-	@Override
-	protected void execute(SlashCommandEvent event) {
+    public MusicCmd() {
+        this.guildOnly = true;
+    }
 
-		AudioManager audioManager = getAudioManager(event.getGuild());
-		VoiceChannel memberVoiceChannel = getChannel(event);
+    /**
+     * Entry point called by CommandRouter when a slash command is triggered.
+     */
+    public void execute(SlashCommandInteractionEvent event) {
 
-		/*
-		 * To execute any music command the bot needs to be in a voice channel. It
-		 * validates this. A voice channel is reached by the bot through the Join command.
-		 */
-		if (audioManager.getConnectedChannel() == null) {
-			event.replyEmbeds(MessageUtil.buildMessage("Type `/join`")).queue();
-			return;
-		}
+        if (this.guildOnly && event.getGuild() == null) {
+            event.replyEmbeds(MessageUtil.buildMessage("This command can only be used inside a server.")).queue();
+            return;
+        }
 
-		/*
-		 * It validates if the member who trigger the event is present in a voice channel.
-		 */
-		if (memberVoiceChannel == null) {
-			event.replyEmbeds(MessageUtil.buildMessage("You must be in a voice channel.")).queue();
-			return;
-		}
+        AudioManager audioManager = null;
+        if (event.getGuild() != null) {
+            audioManager = event.getGuild().getAudioManager();
+        }
 
-		command(event);
-	}
+        // If this is a music command and the bot is not connected, tell user to use /join
+        if (audioManager != null && audioManager.getConnectedChannel() == null && !"join".equalsIgnoreCase(name)) {
+            event.replyEmbeds(MessageUtil.buildMessage("Type `/join`")).queue();
+            return;
+        }
 
-	protected AudioSendHandlerImpl getAudioSendHandler(Guild guild) {
-		return (AudioSendHandlerImpl) guild.getAudioManager().getSendingHandler();
-	}
+        VoiceChannel memberVoiceChannel = getChannel(event);
+        if (memberVoiceChannel == null && !"join".equalsIgnoreCase(name)) {
+            event.replyEmbeds(MessageUtil.buildMessage("You must be in a voice channel.")).queue();
+            return;
+        }
 
-	protected AudioPlayer getAudioPlayer(AudioSendHandlerImpl audioSendHandler) {
-		return audioSendHandler.getAudioPlayer();
-	}
+        command(event);
+    }
 
-	protected Guild getGuild(SlashCommandEvent event) {
-		return event.getGuild();
-	}
+    protected AudioSendHandlerImpl getAudioSendHandler(Guild guild) {
+        return (AudioSendHandlerImpl) guild.getAudioManager().getSendingHandler();
+    }
 
-	protected AudioManager getAudioManager(Guild guild) {
-		return guild.getAudioManager();
-	}
+    protected Guild getGuild(SlashCommandInteractionEvent event) {
+        return event.getGuild();
+    }
 
-	protected VoiceChannel getChannel(SlashCommandEvent event) {
-		return event.getMember().getVoiceState().getChannel();
-	}
+    protected AudioManager getAudioManager(Guild guild) {
+        return guild.getAudioManager();
+    }
 
-	public abstract void command(SlashCommandEvent event);
+    protected VoiceChannel getChannel(SlashCommandInteractionEvent event) {
+        if (event.getMember() == null || event.getMember().getVoiceState() == null) return null;
+        return event.getMember().getVoiceState().getChannel();
+    }
 
+    public abstract void command(SlashCommandInteractionEvent event);
 }

--- a/src/main/java/io/github/brendonmiranda/bot/clancy/command/StopCmd.java
+++ b/src/main/java/io/github/brendonmiranda/bot/clancy/command/StopCmd.java
@@ -1,14 +1,11 @@
 package io.github.brendonmiranda.bot.clancy.command;
 
-import com.jagrosh.jdautilities.command.CommandEvent;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import io.github.brendonmiranda.bot.clancy.listener.AudioSendHandlerImpl;
 import io.github.brendonmiranda.bot.clancy.util.MessageUtil;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.managers.AudioManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
@@ -17,36 +14,33 @@ import org.springframework.stereotype.Component;
 @Component
 public class StopCmd extends MusicCmd {
 
-	private static final Logger logger = LoggerFactory.getLogger(StopCmd.class);
+    public StopCmd() {
+        this.name = "stop";
+        this.help = "stops the current song";
+    }
 
-	public StopCmd() {
-		this.name = "stop";
-		this.help = "stops the current song";
-	}
+    public void command(SlashCommandInteractionEvent event) {
 
-	public void command(SlashCommandEvent event) {
+        stop(event.getGuild());
+        event.replyEmbeds(MessageUtil.buildMessage("The player has stopped.")).queue();
+    }
 
-		stop(event.getGuild());
-		event.replyEmbeds(MessageUtil.buildMessage("The player has stopped.")).queue();
-	}
+    // stop method has been separated to allow reuse of it in the code
+    public void stop(Guild guild) {
 
-	// stop method has been separated to allow reuse of it in the code
-	public void stop(Guild guild) {
+        AudioManager audioManager = getAudioManager(guild);
+        AudioSendHandlerImpl audioSendHandler = getAudioSendHandler(guild);
 
-		AudioManager audioManager = getAudioManager(guild);
-		AudioSendHandlerImpl audioSendHandler = getAudioSendHandler(guild);
+        if (audioSendHandler != null) {
+            AudioPlayer audioPlayer = audioSendHandler.getAudioPlayer();
 
-		if (audioSendHandler != null) {
-			AudioPlayer audioPlayer = getAudioPlayer(audioSendHandler);
+            audioPlayer.stopTrack();
 
-			audioPlayer.stopTrack();
+            // pause music to prevent the next one from starting paused
+            if (audioPlayer.isPaused())
+                audioPlayer.setPaused(false);
+        }
 
-			// pause music to prevent the next one from starting paused
-			if (audioPlayer.isPaused())
-				audioPlayer.setPaused(false);
-		}
-
-		audioManager.closeAudioConnection();
-	}
-
+        audioManager.closeAudioConnection();
+    }
 }

--- a/src/main/java/io/github/brendonmiranda/bot/clancy/configuration/JDAConfiguration.java
+++ b/src/main/java/io/github/brendonmiranda/bot/clancy/configuration/JDAConfiguration.java
@@ -1,12 +1,8 @@
 package io.github.brendonmiranda.bot.clancy.configuration;
 
-import com.jagrosh.jdautilities.command.CommandClient;
-import com.jagrosh.jdautilities.command.CommandClientBuilder;
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
-import io.github.brendonmiranda.bot.clancy.command.*;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,55 +14,34 @@ import javax.security.auth.login.LoginException;
 import static net.dv8tion.jda.api.entities.Activity.listening;
 
 /**
- * @author brendonmiranda
+ * Reworked to use JDA 5 and CommandRouter
  */
 @Configuration
 public class JDAConfiguration {
 
-	@Value("${bot.token}")
-	private String token;
+    @Value("${bot.token}")
+    private String token;
 
-	@Value("${bot.prefix}")
-	private String prefix;
+    @Bean
+    public JDA load() throws LoginException {
+        // Create JDA 5 instance
+        JDA jda = JDABuilder.createDefault(token)
+                .setActivity(listening("type /join"))
+                .build();
 
-	@Value("${bot.owner}")
-	private Long owner;
+        // CommandRouter is a component that receives JDA via constructor injection and will
+        // register commands after startup.
+        return jda;
+    }
 
-	@Bean
-	public JDA load(PlayCmd playCmd, StopCmd stopCmd, PauseCmd pauseCmd, ResumeCmd resumeCmd, SkipCmd skipCmd,
-			NowPlayingCmd nowPlayingCmd, JoinCmd joinCmd) throws LoginException {
-
-		JDA jda = JDABuilder.createDefault(token).build();
-
-		CommandClient cmdListener = new CommandClientBuilder().setPrefix(prefix)
-			.setOwnerId(Long.toString(owner))
-			.addSlashCommands(playCmd, stopCmd, pauseCmd, resumeCmd, skipCmd, nowPlayingCmd, joinCmd)
-			.setActivity(listening("type /join"))
-			.build();
-		// todo: set watching activity
-
-		jda.addEventListener(cmdListener, eventWaiter());
-
-		return jda;
-	}
-
-	@Bean
-	public EventWaiter eventWaiter() {
-		return new EventWaiter();
-	}
-
-	/**
-	 * If possible, you should use a single instance of a player manager for your whole
-	 * application. A player manager manages several thread pools which make no sense to
-	 * duplicate.
-	 * @return AudioPlayerManager
-	 */
-	@Bean
-	public AudioPlayerManager audioPlayerManager() {
-
-		AudioPlayerManager audioPlayerManager = new DefaultAudioPlayerManager();
-		AudioSourceManagers.registerRemoteSources(audioPlayerManager);
-		return audioPlayerManager;
-	}
-
+    /**
+     * Use a single instance of AudioPlayerManager for the app.
+     * @return AudioPlayerManager
+     */
+    @Bean
+    public AudioPlayerManager audioPlayerManager() {
+        AudioPlayerManager audioPlayerManager = new DefaultAudioPlayerManager();
+        AudioSourceManagers.registerRemoteSources(audioPlayerManager);
+        return audioPlayerManager;
+    }
 }

--- a/src/main/java/io/github/brendonmiranda/bot/clancy/listener/PlayResultHandler.java
+++ b/src/main/java/io/github/brendonmiranda/bot/clancy/listener/PlayResultHandler.java
@@ -1,7 +1,5 @@
 package io.github.brendonmiranda.bot.clancy.listener;
 
-import com.jagrosh.jdautilities.commons.waiter.EventWaiter;
-import com.jagrosh.jdautilities.menu.OrderedMenu;
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
@@ -13,13 +11,11 @@ import io.github.brendonmiranda.bot.clancy.service.AudioQueueService;
 import io.github.brendonmiranda.bot.clancy.util.MessageUtil;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.managers.AudioManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.TimeUnit;
 
 import static io.github.brendonmiranda.bot.clancy.command.PlayCmd.MUSIC_ARG;
 
@@ -28,165 +24,135 @@ import static io.github.brendonmiranda.bot.clancy.command.PlayCmd.MUSIC_ARG;
  */
 public class PlayResultHandler implements AudioLoadResultHandler {
 
-	private static final Logger logger = LoggerFactory.getLogger(PlayResultHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(PlayResultHandler.class);
 
-	private final AudioPlayer audioPlayer;
+    private final AudioPlayer audioPlayer;
 
-	private final Guild guild;
+    private final Guild guild;
 
-	private final AudioManager audioManager;
+    private final AudioManager audioManager;
 
-	private final SlashCommandEvent event;
+    private final SlashCommandInteractionEvent event;
 
-	private final AudioPlayerManager audioPlayerManager;
+    private final AudioPlayerManager audioPlayerManager;
 
-	private final EventWaiter eventWaiter;
+    private final Message message;
 
-	private final Message message;
+    private final boolean ytSearch;
 
-	private final OrderedMenu.Builder builder;
+    private final AudioQueueService audioQueueService;
 
-	private final boolean ytSearch;
+    public PlayResultHandler(AudioPlayer audioPlayer, Guild guild, AudioManager audioManager, SlashCommandInteractionEvent event,
+                             AudioPlayerManager audioPlayerManager, Message message, boolean ytSearch,
+                             AudioQueueService audioQueueService) {
+        this.audioPlayer = audioPlayer;
+        this.guild = guild;
+        this.audioManager = audioManager;
+        this.event = event;
+        this.audioPlayerManager = audioPlayerManager;
+        this.message = message;
+        this.ytSearch = ytSearch;
+        this.audioQueueService = audioQueueService;
+    }
 
-	private final AudioQueueService audioQueueService;
+    @Override
+    public void trackLoaded(AudioTrack track) {
+        AudioTrackInfo audioTrackInfo = track.getInfo();
+        logger.info("Track has loaded. Title: {}, author: {}, identifier: {}, source: {}", audioTrackInfo.title,
+                audioTrackInfo.author, audioTrackInfo.identifier, track.getSourceManager());
 
-	public PlayResultHandler(AudioPlayer audioPlayer, Guild guild, AudioManager audioManager, SlashCommandEvent event,
-			AudioPlayerManager audioPlayerManager, EventWaiter eventWaiter, Message message, boolean ytSearch,
-			AudioQueueService audioQueueService) {
-		this.audioPlayer = audioPlayer;
-		this.guild = guild;
-		this.audioManager = audioManager;
-		this.event = event;
-		this.audioPlayerManager = audioPlayerManager;
-		this.eventWaiter = eventWaiter;
-		this.message = message;
-		this.ytSearch = ytSearch;
-		this.builder = new OrderedMenu.Builder().allowTextInput(true)
-			.useNumbers()
-			.useCancelButton(true)
-			.setEventWaiter(eventWaiter)
-			.setTimeout(1, TimeUnit.MINUTES);
-		this.audioQueueService = audioQueueService;
-	}
+        manageTrack(track);
+    }
 
-	@Override
-	public void trackLoaded(AudioTrack track) {
-		AudioTrackInfo audioTrackInfo = track.getInfo();
-		logger.info("Track has loaded. Title: {}, author: {}, identifier: {}, source: {}", audioTrackInfo.title,
-				audioTrackInfo.author, audioTrackInfo.identifier, track.getSourceManager());
+    /**
+     * Plays the track if none is being played otherwise it is enqueued.
+     * @param track audio track
+     */
+    public void manageTrack(AudioTrack track) {
 
-		manageTrack(track);
-	}
+        AudioSendHandlerImpl audioSendHandler = (AudioSendHandlerImpl) audioManager.getSendingHandler();
 
-	/**
-	 * Plays the track if none is being played otherwise it is enqueued.
-	 * @param track audio track
-	 */
-	public void manageTrack(AudioTrack track) {
+        // Store guild to be recovered when needed as we do on AudioEventListener
+        track.setUserData(guild);
 
-		AudioSendHandlerImpl audioSendHandler = (AudioSendHandlerImpl) audioManager.getSendingHandler();
+        if (audioSendHandler == null) {
+            audioManager.setSendingHandler(new AudioSendHandlerImpl(audioPlayer));
+            playTrack(this.audioPlayer, track);
+        }
+        else {
+            AudioPlayer audioPlayer = audioSendHandler.getAudioPlayer();
 
-		// Store guild to be recovered when needed as we do on AudioEventListener
-		track.setUserData(guild);
+            if (audioPlayer.getPlayingTrack() != null)
+                queueTrack(audioPlayer, track);
+            else
+                playTrack(audioPlayer, track);
+        }
+    }
 
-		if (audioSendHandler == null) {
-			audioManager.setSendingHandler(new AudioSendHandlerImpl(audioPlayer));
-			playTrack(this.audioPlayer, track);
-		}
-		else {
-			AudioPlayer audioPlayer = audioSendHandler.getAudioPlayer();
+    private void queueTrack(AudioPlayer audioPlayer, AudioTrack track) {
 
-			if (audioPlayer.getPlayingTrack() != null)
-				queueTrack(audioPlayer, track);
-			else
-				playTrack(audioPlayer, track);
-		}
-	}
+        audioQueueService.enqueue(guild.getName(), track);
 
-	private void queueTrack(AudioPlayer audioPlayer, AudioTrack track) {
+        event.getChannel().sendMessageEmbeds(MessageUtil.buildMessage("Enqueued", track.getInfo().title)).queue();
 
-		audioQueueService.enqueue(guild.getName(), track);
+        if (audioPlayer.isPaused()) {
+            event.getChannel()
+                .sendMessageEmbeds(MessageUtil.buildMessage("Alert",
+                        "The track `" + audioPlayer.getPlayingTrack().getInfo().title
+                                + "` is paused. \n\nType `/resume` to unpause."))
+                .queue();
+        }
+    }
 
-		event.getChannel().sendMessageEmbeds(MessageUtil.buildMessage("Enqueued", track.getInfo().title)).queue();
+    private void playTrack(AudioPlayer audioPlayer, AudioTrack track) {
 
-		if (audioPlayer.isPaused()) {
-			event.getChannel()
-				.sendMessageEmbeds(MessageUtil.buildMessage("Alert",
-						"The track `" + audioPlayer.getPlayingTrack().getInfo().title
-								+ "` is paused. \n\nType `/resume` to unpause."))
-				.queue();
+        audioPlayer.playTrack(track);
 
-		}
+        event.getChannel()
+            .sendMessageEmbeds(MessageUtil.buildMessage("Playing", audioPlayer.getPlayingTrack().getInfo().title))
+            .queue();
+    }
 
-	}
+    @Override
+    public void playlistLoaded(final AudioPlaylist playlist) {
+        OptionMapping option = event.getOption(MUSIC_ARG);
+        String args = option != null ? option.getAsString() : "";
 
-	private void playTrack(AudioPlayer audioPlayer, AudioTrack track) {
+        // simplified behavior: list top results
+        if (playlist.isSearchResult()) {
+            StringBuilder sb = new StringBuilder("Search `").append(args).append("`:\n");
+            for (int i = 0; i < Math.min(5, playlist.getTracks().size()); i++) {
+                sb.append(i + 1).append(") ").append(playlist.getTracks().get(i).getInfo().title).append("\n");
+            }
+            sb.append("\nTo play, run `/play <query>`.");
+            event.getChannel().sendMessage(sb.toString()).queue();
+        }
+        else {
+            event.getChannel()
+                .sendMessageEmbeds(MessageUtil.buildMessage("Sorry, I'm unable to load a playlist."))
+                .queue();
+        }
+    }
 
-		audioPlayer.playTrack(track);
+    @Override
+    public void noMatches() {
+        OptionMapping option = event.getOption(MUSIC_ARG);
+        String args = option != null ? option.getAsString() : "";
 
-		event.getChannel()
-			.sendMessageEmbeds(MessageUtil.buildMessage("Playing", audioPlayer.getPlayingTrack().getInfo().title))
-			.queue();
+        // conditional to avoid loop
+        if (!ytSearch)
+            audioPlayerManager.loadItem("ytsearch:" + args, new PlayResultHandler(audioPlayer, guild, audioManager,
+                    event, audioPlayerManager, message, true, audioQueueService));
+        else
+            event.getChannel()
+                .sendMessageEmbeds(
+                        MessageUtil.buildMessage("Sorry, I couldn't find your track. Please, rephrase and try again."))
+                .queue();
+    }
 
-	}
-
-	/**
-	 * Manages the loading result of noMatches method
-	 * @param playlist playlist loaded
-	 */
-	@Override
-	public void playlistLoaded(final AudioPlaylist playlist) {
-		OptionMapping option = event.getOption(MUSIC_ARG);
-		String args = option.getAsString();
-
-		// todo: log playlist loaded
-		if (playlist.isSearchResult()) {
-
-			builder.setDescription("Search `" + args + "`: \n").setSelection((msg, i) -> {
-				AudioTrack audioTrack = playlist.getTracks().get(i - 1);
-				manageTrack(audioTrack);
-			}).setCancel((msg) -> {
-			}).setUsers(event.getUser()).setColor(MessageUtil.DEFAULT_COLOR);
-
-			for (int i = 0; i <= 4; i++) {
-				AudioTrack audioTrack = playlist.getTracks().get(i);
-				builder.addChoice(audioTrack.getInfo().title);
-			}
-
-			builder.build().display(message);
-
-		}
-		else {
-			event.getChannel()
-				.sendMessageEmbeds(MessageUtil.buildMessage("Sorry, I'm unable to load a playlist."))
-				.queue();
-		}
-	}
-
-	/**
-	 * Loads a "playlist" made of the search results when the attempt of loading on
-	 * PlayCmd doesn't match. In case of fail it returns an error message.
-	 */
-	@Override
-	public void noMatches() {
-		OptionMapping option = event.getOption(MUSIC_ARG);
-		String args = option.getAsString();
-
-		// conditional to avoid loop
-		if (!ytSearch)
-			audioPlayerManager.loadItem("ytsearch:" + args, new PlayResultHandler(audioPlayer, guild, audioManager,
-					event, audioPlayerManager, eventWaiter, message, true, audioQueueService));
-		else
-			event.getChannel()
-				.sendMessageEmbeds(
-						MessageUtil.buildMessage("Sorry, I couldn't find your track. Please, rephrase and try again."))
-				.queue();
-	}
-
-	@Override
-	public void loadFailed(final FriendlyException exception) {
-		logger.error("Loading audio has failed. Severity: {}.", exception.severity);
-		throw exception;
-	}
-
+    @Override
+    public void loadFailed(final FriendlyException exception) {
+        logger.error("Loading audio has failed. Severity: {}.", exception.severity);
+        throw exception;
+    }
 }


### PR DESCRIPTION
**Everything in this PR is generated by AI**
For now it hasn't even build. Lets see where that goes.

Summary

  - Upgrades JDA to 5.x to gain AEAD voice encryption support (resolves voice handshake errors).
  - Removes reliance on jdautilities / jda-chewtils and introduces a small in-repo CommandRouter + simplified command base so existing commands continue to work under JDA 5.
  - Simplifies playlist UX (removed OrderedMenu/EventWaiter) to avoid reintroducing incompatible libraries; playlist results are now shown as a short text list.

  Files changed
  - build.gradle — bump to JDA 5
  - command/MusicCmd.java — new simplified command base
  - command/CommandRouter.java — new command registration + dispatch
  - configuration/JDAConfiguration.java — JDA 5 creation
  - listener/PlayResultHandler.java — adapt to SlashCommandInteractionEvent, remove OrderedMenu dependency
  - command/StopCmd.java — adapt to new event type

  How to test
  1. Build: ./gradlew clean build
  2. Run the bot with a valid BOT token and invite it to a test guild.
  3. Use /join to make the bot join a voice channel; confirm the AEAD-related error is gone.
  4. Test /play, /pause, /resume, /skip, /stop.

  Notes
  - Slash commands are registered globally (may take up to an hour to propagate). For immediate testing, register commands to a specific test guild in CommandRouter (use jda.getGuildById(TEST_GUILD_ID).updateCommands(...)).
  - I removed OrderedMenu/EventWaiter to avoid reintroducing incompatible dependencies; we can add a light in-repo menu implementation if you want the same UX.